### PR TITLE
File type sensitive README processor

### DIFF
--- a/bin/org2html
+++ b/bin/org2html
@@ -1,0 +1,8 @@
+#!/bin/sh -
+# export as HTML with
+#  3       ... render as html headline with org headline level within  3
+#  nil     ... no override of settings
+#  'string ... return string instead of creating a html file
+#  t       ... export body only
+"$1" -Q -batch --file "$2" --eval "(setq org-export-with-toc nil)" --eval "(princ (org-export-as-html 3 nil 'string t))" 2> /dev/null
+

--- a/shlyfile.lisp
+++ b/shlyfile.lisp
@@ -51,6 +51,10 @@
    (connect-db)
    (ql-dist:find-release release-name)))
 
+(defun update-project-readme-database (&optional (dist-version
+                                           (ql-dist:version (ql-dist:dist "quicklisp"))))
+  (quickdocs.updater.project:update-dist-readme-database (connect-db) dist-version))
+
 (defun update-project-database (&optional (dist-version
                                            (ql-dist:version (ql-dist:dist "quicklisp"))))
   (quickdocs.updater.project:update-dist-database (connect-db) dist-version))

--- a/updater/util.lisp
+++ b/updater/util.lisp
@@ -6,7 +6,8 @@
                 :with-output-to-sequence)
   (:import-from :alexandria
                 :copy-stream
-                :with-gensyms)
+                :with-gensyms
+                :read-file-into-string)
   (:import-from :lparallel.kernel
                 :*kernel*
                 :make-channel
@@ -78,9 +79,28 @@
 ;;
 ;; README
 
+;; for plain text
+(defun plain-readme (file)
+  (concatenate 'string "<pre>" (read-file-into-string file) "</pre>"))
+
+;; for markdown
 (defparameter *pandoc-path* "pandoc")
 
 (defun pandoc-readme (file)
   (with-output-to-string (s)
     (sb-ext:run-program "/bin/sh" `("-c" ,(format nil "timeout 10 ~A ~A" *pandoc-path* file))
+                        :output s)))
+
+;; for org-mode
+(defparameter *emacs-path* "/usr/bin/emacs")
+(defun org2html-readme (file)
+  (with-output-to-string (s)
+    (sb-ext:run-program "/bin/sh" `("-c" ,(format nil "timeout 10 bin/org2html ~A ~A " *emacs-path* file))
+                        :output s)))
+
+;; for reStructuredText
+(defparameter *rst2html-path* "rst2html.py")
+(defun rst2html-readme (file)
+  (with-output-to-string (s)
+    (sb-ext:run-program "/bin/sh" `("-c" ,(format nil "timeout 10 ~A ~A" *rst2html-path* file))
                         :output s)))


### PR DESCRIPTION
Currently, it recognizes org-mode and plain text besides markdown.
To update only readmes, run
    shly update-project-readme-database
.

TODO
- rst(reStructuredText) : I know there is a command named `rst2html` but I couldn't find the executable.
- better plain text process : To show 'as it is', it uses `<pre>`, which is rendered with black background. Maybe it is stylesheet to be changed.

BTW to run, I needed to patch like this,

```
diff --git a/updater/model/system.lisp b/updater/model/system.lisp
index 61b7b8e..f262bd1 100644
--- a/updater/model/system.lisp
+++ b/updater/model/system.lisp
@@ -44,5 +44,5 @@
                (run-in-process `(system-info ,system-name)
                                :output s))))
     (when res
-      (read-from-string res))))
+      (read-from-string (read-from-string res)))))

```

Is in running correctly on your environment?
